### PR TITLE
Feature/auto start mqtt msg handler

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,7 +9,7 @@ http{
     server {
         listen 80;
         listen [::]:80;
-        server_name elab.ase.au.dk;
+        server_name localhost;
         server_tokens off;
 
         location ~ /.well-known/acme-challenge/ {
@@ -20,7 +20,7 @@ http{
         location / {
             proxy_pass http://webinterface:8001/;
             proxy_redirect     off;
-            proxy_set_header    Host                $http_host;
+            proxy_set_header    Host                $host;
             proxy_set_header    X-Real-IP           $remote_addr;
             proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
         }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,7 +9,7 @@ http{
     server {
         listen 80;
         listen [::]:80;
-        server_name localhost;
+        server_name elab.ase.au.dk;
         server_tokens off;
 
         location ~ /.well-known/acme-challenge/ {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,6 +19,7 @@ http{
 
         location / {
             proxy_pass http://webinterface:8001/;
+            proxy_redirect     off;
             proxy_set_header    Host                $http_host;
             proxy_set_header    X-Real-IP           $remote_addr;
             proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,7 +9,7 @@ http{
     server {
         listen 80;
         listen [::]:80;
-        server_name team2;
+        server_name localhost;
         server_tokens off;
 
         location ~ /.well-known/acme-challenge/ {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,10 +19,10 @@ http{
 
         location / {
             proxy_pass http://webinterface:8001/;
-            proxy_redirect     off;
-            proxy_set_header    Host                $host;
+            proxy_set_header    Host                $http_host;
             proxy_set_header    X-Real-IP           $remote_addr;
             proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
         }
 
           location /videostream/ {

--- a/webinterface/entrypoint.sh
+++ b/webinterface/entrypoint.sh
@@ -30,5 +30,16 @@ python manage.py collectstatic --no-input --clear
 #Add tasks to the crontab scheduler
 python manage.py crontab add
 
+echo "Waiting for MQTT service before starting Message Handler"
+
+#Use netcat to scan for daemons, we wait until our MQTT service is running
+while ! nc -z mqtt 8000; do
+  sleep 0.1
+done
+
+echo "MQTT started... Starting Message Handler"
+
+python manage.py start_messagehandler
+
 #Expand all positional arguments to this script and execute them, hand over control
 exec "$@"

--- a/webinterface/entrypoint.sh
+++ b/webinterface/entrypoint.sh
@@ -33,13 +33,13 @@ python manage.py crontab add
 echo "Waiting for MQTT service before starting Message Handler"
 
 #Use netcat to scan for daemons, we wait until our MQTT service is running
-while ! nc -z mqtt 8000; do
-  sleep 0.1
-done
+#while ! nc -z mqtt 8000; do
+#  sleep 0.1
+#done
 
 echo "MQTT started... Starting Message Handler"
 
-python manage.py start_messagehandler
+#python manage.py start_messagehandler
 
 #Expand all positional arguments to this script and execute them, hand over control
 exec "$@"

--- a/webinterface/webinterface/settings.py
+++ b/webinterface/webinterface/settings.py
@@ -22,7 +22,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'cfh16z33oa@=vl^*5mfhsy&#4b6()l^usx3l#xo8llo)d=g6ox'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = [
     'localhost',
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = [
     '192.168.1.7',
     'webinterface',
     '192.168.0.16',
+    'elab.ase.au.dk'
 ]
 
 # Application definition


### PR DESCRIPTION
We need to start the messagehandler manually for now

There is an up-stream routing error (nginx goes down) when starting "start_messagehandler" in entrypoint.sh (even with netstat check that the service is up), but the error does not occur if the command is provided using docker-compose exec (i.e. manually) 