### PR TITLE
Add restart unless-stopped to webinterface

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
   webinterface:
     build: ./webinterface
+    restart: unless-stopped
     image: janusboandersen/auwebinterface2020:webinterface
     ports:
       - "8001:8001"


### PR DESCRIPTION
When merged this commit fixes that the server-setup may randomly stop due to missing restart config for webinterface image
